### PR TITLE
deactivate the if-modifier rule

### DIFF
--- a/conf/rubocop.yml
+++ b/conf/rubocop.yml
@@ -70,7 +70,10 @@ Layout/IndentFirstArrayElement:
 
 Metrics/ClassLength:
   Max: 200
-
+  
+Style/IfUnlessModifier:
+  Enabled: false
+  
 Style/RedundantSelf:
   Enabled: false
 


### PR DESCRIPTION
For long lines it's easy to miss the condition at the very end of the line. It doesn't seem to be possible to define a max line length only for the if-modifier case. (see e.g. https://github.com/rubocop-hq/rubocop/issues/6149). So best action right now is to deactivate the rule and let the dev decide...